### PR TITLE
features/android_agp8_fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    
+    namespace 'com.chartbeat.flutter'
     compileSdkVersion 31
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.example.chartbeat_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
Flutter now requires Android Gradle Plugin 8+, which introduces a few breaking changes that affect Android libraries:
- `namespace` must be explicitly declared in `android/build.gradle`
- the `package` attribute must be removed from `AndroidManifest.xml`